### PR TITLE
Fix windows build issue by putting double quotes for --define flag

### DIFF
--- a/lib/webview/project.json
+++ b/lib/webview/project.json
@@ -14,7 +14,7 @@
       "executor": "nx:run-commands",
       "options": {
         "cwd": "lib/webview",
-        "command": "npx esbuild build/webview.js --external:vscode '--define:process.env.NODE_ENV=\"production\"' --bundle --platform=browser --outfile=dist/webview.js"
+        "command": "npx esbuild build/webview.js --external:vscode --define:process.env.NODE_ENV=\"production\" --bundle --platform=browser --outfile=dist/webview.js"
       }
     }
   }


### PR DESCRIPTION
**Changes**:
- Replaced single quotes with double quotes in the `--define` flag in `lib/webview/project.json`.

**Issue**:
Fixes #22 

**Environment**:
* Windows 10
* pnpm v9.1.1