### PR TITLE
Fix pnpm "missing dependency" error

### DIFF
--- a/app/vscode/package.json
+++ b/app/vscode/package.json
@@ -5,7 +5,7 @@
   "scripts": {},
   "devDependencies": {},
   "dependencies": {
-    "@pearai/extension": "*",
-    "@pearai/webview": "*"
+    "@pearai/extension": "workspace:*",
+    "@pearai/webview": "workspace:*"
   }
 }

--- a/lib/extension/package.json
+++ b/lib/extension/package.json
@@ -12,7 +12,7 @@
     "@types/vscode": "1.72.0"
   },
   "dependencies": {
-    "@pearai/common": "*",
+    "@pearai/common": "workspace:*",
     "handlebars": "4.7.8",
     "marked": "4.2.12",
     "modelfusion": "0.135.1",

--- a/lib/webview/package.json
+++ b/lib/webview/package.json
@@ -12,7 +12,7 @@
     "eslint-plugin-react": "^7.32.1"
   },
   "dependencies": {
-    "@pearai/common": "*",
+    "@pearai/common": "workspace:*",
     "prismjs": "1.29.0",
     "react": "18.2.0",
     "react-diff-viewer-continued": "3.2.5",


### PR DESCRIPTION
Resolved an issue where workspace dependencies were incorrectly installed. Previously, dependencies were being installed using `*` instead of `workspace:*`, causing errors during the build process.

**Error fixed:** Dependencies were not correctly recognized and linked within the NX workspace, leading to inconsistent behavior and build failures.

![Dependency Installation Error](https://github.com/trypear/pearai-extension/assets/25815579/1b8741fa-9780-48ed-8ee2-e11bb93e128b)

This change ensures that all workspace dependencies are accurately referenced and installed as `workspace:*`.
