### PR TITLE
Resolved Issue with Error Message Styling in Chat Window

### DIFF
--- a/lib/webview/asset/chat.css
+++ b/lib/webview/asset/chat.css
@@ -241,6 +241,9 @@ body {
 .error-body {
   display: flex;
   justify-content: space-between;
+  overflow-wrap: anywhere;
+  flex-direction: column;
+  gap: 1rem;
 }
 
 .error-body>.error-retry {
@@ -269,6 +272,11 @@ body {
   cursor: pointer;
   text-align: center;
   margin-top: var(--pearai-container-padding);
+}
+
+.error-retry { 
+  min-width: fit-content;
+  align-self: end;
 }
 
 button.error-retry,


### PR DESCRIPTION
Previously, the error message box in the chat window could overflow on smaller panel widths, causing an undesired horizontal scroll.

**Error Fixed:** The error message box was not properly contained within the parent element, leading to display issues and user interface inconsistencies on a smaller sidebar width. 

**Changes:** The CSS styling has been changed to ensure the error message box remains within the bounds of the parent element. Additionally, the retry button has been moved to the bottom-right of the error message for clarity.

**Visual Comparison:**

Before:

![Before](https://github.com/trypear/pearai-extension/assets/13270623/9a1440e1-c499-40b1-846e-4e8e5abfb4e9)

After:

![After](https://github.com/trypear/pearai-extension/assets/13270623/e2410355-6a1d-44ce-a901-6ed55ea73572)


The styling changes ensure that the error message is contained inside the parent, and the retry button is not crammed on one side.